### PR TITLE
The intword() method always returns a string now

### DIFF
--- a/humanize.js
+++ b/humanize.js
@@ -262,7 +262,7 @@ Humanize.intword = function( number ) {
 	} else if( number < 1000000000000000 ) {
 		return Humanize.intcomma( number / 1000000000000.0, 1 ) + " trillion";
 	} 
-	return number;	// too big.
+	return "" + number;	// too big.
 }
 
 
@@ -383,7 +383,7 @@ Humanize.naturalTime = function( timestamp, format ) {
 			} else if ( minutes === 1 ) {
 				return "one minute ago";
 			} else {
-				return ""+minutes+" minutes ago";
+				return minutes+" minutes ago";
 			}
 		}
 	}


### PR DESCRIPTION
I figured it probably makes sense to always return a string, Since it's unlikely anyone really wants to check the type of the object each time they call the method. 

Also the naturalTime method didn't need the leading string coercion, since the suffix was a string. 
